### PR TITLE
catching value lower than -96 db to completely mute the signal

### DIFF
--- a/source/j.model/j.model_signal.cpp
+++ b/source/j.model/j.model_signal.cpp
@@ -250,7 +250,11 @@ void model_signal_return_audio_gain(TTPtr self, t_symbol *msg, long argc, t_atom
         
         jamoma_ttvalue_from_Atom(in, msg, argc, argv);
         
-        EXTRA->dataspaceConverter->send("convert", in, out);
+        // catch value lower than -96 db to completely mute the signal
+        if (TTFloat64(in[0]) <= TTFloat64(-96.))
+            out = 0.;
+        else
+            EXTRA->dataspaceConverter->send("convert", in, out);
         
         aSender.send(kTTSym_Send, out, none);
     }


### PR DESCRIPTION
If you use the patch below on this branch you can see that signal is turned to a zero signal when audio/gain is lower than -96 db : 

<pre><code>
----------begin_max5_patcher----------
550.3oc4UssahCCD84juhn7LaTRfzR6a86XU0JG6AvsFajsCEZU4aesGmTLz
xE09xJsuXvmY7b4LmAdKMIuUsAL4Y2m86rjj2RSRPHOPR+8j7kjMTAwftkK6
V1B5c4iB1VQrzEb47+nApMDmIiKJGk0fmSwy55hxrG6eAmgwQ09zuZFhxLkz
JIKAzxCZNQLXwkNtT.VL408fF6VQv2H2Tc1i8aohAw28oYFghXkQXF9qHVkq
N6gCQytcEDZpbCetzWVY4yDJhqUG5GmALdEk96uml5OFckrI7JiPOGYVe6Dj
AqlTzLJaRi+h+7qnyI+HR66T9WVLTcWP.bi+ipxomSNT+eubPBu3HhgtvBaP
VLmtkJfcY0WjmqpvUulywxU+Htr5BDR1iei1tEaHPOjx0b3k0bCukK31sGj1
YyLPeKW56xxnlTnnOCLllL2P0JgHdtREb5y1EZU27Ew3fjzJfEe9AACq+rg1
4C5nOPTZlq3iPN4.5Nb.MtrLrNbhE4pyOi9X0XYmvxYffrcWgqn5DPgiWcI+
qmciurXd+21qnWoACHsDKWIiZnA5+31IZ9igHWvkG+WLH+3wOTTXTcZ5PQMP
DY6oHFXrbIVHQNUefOK3LFHiGFLtwOJYm9G4t5x4Jpll+opliHvqubBiNxpU
qAsoOlXk31beRgh8aGgW4R0dsetF7KtA+aPDh1sJXcxlNcP0tY5M4gm51izx
NNtfm5y76o+E87n+9A
-----------end_max5_patcher-----------
</code></pre>
