### PR TITLE
Cmake: when building for Max on the Mac, don't include the version nu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ html
 Debug
 Release
 Makefile
+Jamoma/externals
+Jamoma/extensions
+Jamoma/support
 
 # XCode files to be ignored
 xcuserdata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,6 @@ endif()
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/library/includes/JamomaMaxVersion.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/library/includes/JamomaMaxVersion.h" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Jamoma/javascript/j.js_systeminfo.js.in" "${CMAKE_CURRENT_SOURCE_DIR}/Jamoma/javascript/j.js_systeminfo.js" @ONLY)
 
-if(NOT JAMOMA_UMBRELLA)
-
     if (APPLE)
         option(FAT_BINARY "Build a fat binary (32bit and 64bit)" ON)
     endif(APPLE)
@@ -77,9 +75,11 @@ if(NOT JAMOMA_UMBRELLA)
         DESTINATION ${JAMOMAMAX_INSTALL_FOLDER}
             COMPONENT JamomaMax)
     add_subdirectory(${JAMOMA_CORE_SRC_PATH})
-else()
-	set(JAMOMA_CORE_SRC_PATH "${PROJECT_SOURCE_DIR}/../../Core/")
-endif()
+
+
+
+
+
 
 if((APPLE AND NOT IOS) OR WIN32)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -170,11 +170,15 @@ if(APPLE)
 	ADD_CUSTOM_COMMAND(
 	  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
 	  POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-     ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+#	  COMMAND ${CMAKE_COMMAND} -E make_directory
+#	  	${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+  	  COMMAND ${CMAKE_COMMAND} -E make_directory
+  	  	${CMAKE_BINARY_DIR}/Debug/support
+  	  COMMAND ${CMAKE_COMMAND} -E make_directory
+  	  	${CMAKE_BINARY_DIR}/Release/support
 	  COMMAND ${CMAKE_COMMAND} -E copy
-	      ${CMAKE_BINARY_DIR}/library/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.dylib #* # we have to be careful with .so / .dll
-	      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+	  	${CMAKE_BINARY_DIR}/library/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.dylib #* # we have to be careful with .so / .dll
+		${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
 	)
 endif() # APPLE
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -166,20 +166,21 @@ target_link_libraries(${PROJECT_NAME} Modular)
 
 
 if(APPLE)
-
-	ADD_CUSTOM_COMMAND(
-	  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
-	  POST_BUILD
-#	  COMMAND ${CMAKE_COMMAND} -E make_directory
-#	  	${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
-  	  COMMAND ${CMAKE_COMMAND} -E make_directory
-  	  	${CMAKE_BINARY_DIR}/Debug/support
-  	  COMMAND ${CMAKE_COMMAND} -E make_directory
-  	  	${CMAKE_BINARY_DIR}/Release/support
-	  COMMAND ${CMAKE_COMMAND} -E copy
-	  	${CMAKE_BINARY_DIR}/library/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.dylib #* # we have to be careful with .so / .dll
-		${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
-	)
+	if(!$ENV{TRAVIS})
+		ADD_CUSTOM_COMMAND(
+		  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
+		  POST_BUILD
+	#	  COMMAND ${CMAKE_COMMAND} -E make_directory
+	#	  	${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+	  	  COMMAND ${CMAKE_COMMAND} -E make_directory
+	  	  	${CMAKE_BINARY_DIR}/Debug/support
+	  	  COMMAND ${CMAKE_COMMAND} -E make_directory
+	  	  	${CMAKE_BINARY_DIR}/Release/support
+		  COMMAND ${CMAKE_COMMAND} -E copy
+		  	${CMAKE_BINARY_DIR}/library/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.dylib #* # we have to be careful with .so / .dll
+			${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+		)
+	endif() # !$ENV{TRAVIS}		
 endif() # APPLE
 
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -70,12 +70,12 @@ set_property(TARGET ${PROJECT_NAME}
 			 PROPERTY BUILD_WITH_INSTALL_RPATH TRUE)
 
 # Version
-set_property(TARGET ${PROJECT_NAME}
-			 PROPERTY VERSION ${Jamoma_VERSION})
-set_property(TARGET ${PROJECT_NAME}
-			 PROPERTY SOVERSION ${Jamoma_SOVERSION})
-set_property(TARGET ${PROJECT_NAME} APPEND
-			 PROPERTY COMPATIBLE_INTERFACE_STRING Jamoma_MAJOR_VERSION)
+# set_property(TARGET ${PROJECT_NAME}
+# 			 PROPERTY VERSION ${Jamoma_VERSION})
+# set_property(TARGET ${PROJECT_NAME}
+# 			 PROPERTY SOVERSION ${Jamoma_SOVERSION})
+# set_property(TARGET ${PROJECT_NAME} APPEND
+# 			 PROPERTY COMPATIBLE_INTERFACE_STRING Jamoma_MAJOR_VERSION)
 
 # TODO replace with target_include_directories
 if(APPLE)
@@ -161,6 +161,28 @@ target_link_libraries(${PROJECT_NAME} ${Jitter_LIB})
 
 target_link_libraries(${PROJECT_NAME} Foundation)
 target_link_libraries(${PROJECT_NAME} Modular)
+
+
+
+
+if(APPLE)
+
+	ADD_CUSTOM_COMMAND(
+	  TARGET ${PROJECT_NAME}
+	  POST_BUILD
+	  COMMAND ${CMAKE_COMMAND} -E make_directory
+	   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
+	)
+	ADD_CUSTOM_COMMAND(
+	  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
+	  POST_BUILD
+	  COMMAND ${CMAKE_COMMAND} -E copy
+	      ${CMAKE_BINARY_DIR}/library/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.dylib #* # we have to be careful with .so / .dll
+	      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib
+	)
+endif() # APPLE
+
+
 
 ### Tests ###
 addTestTarget()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -168,14 +168,10 @@ target_link_libraries(${PROJECT_NAME} Modular)
 if(APPLE)
 
 	ADD_CUSTOM_COMMAND(
-	  TARGET ${PROJECT_NAME}
-	  POST_BUILD
-	  COMMAND ${CMAKE_COMMAND} -E make_directory
-	   ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
-	)
-	ADD_CUSTOM_COMMAND(
 	  TARGET ${PROJECT_NAME} #Jamoma::Foundation # for instance
 	  POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+     ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support
 	  COMMAND ${CMAKE_COMMAND} -E copy
 	      ${CMAKE_BINARY_DIR}/library/${CMAKE_BUILD_TYPE}/lib${PROJECT_NAME}.dylib #* # we have to be careful with .so / .dll
 	      ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/support #/libJamomaFoundation.dylib

--- a/link.sh
+++ b/link.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# run this script from the root of the JamomaMax repository after running build.sh with the --xcode option
+# this will make symlinks to the build inside of the package itself to make it easier to interactively debug with xcode
+
+PWD=`pwd`
+SUPPORT="$PWD/Jamoma/support"
+
+FOUNDATION="$PWD/build-xcode/JamomaCore/Foundation"
+DSP="$PWD/build-xcode/JamomaCore/DSP"
+GRAPH="$PWD/build-xcode/JamomaCore/Graph"
+AUDIOGRAPH="$PWD/build-xcode/JamomaCore/AudioGraph"
+MODULAR="$PWD/build-xcode/JamomaCore/Modular"
+SCORE="$PWD/build-xcode/JamomaCore/Score"
+
+rm -rf $PWD/Jamoma/externals
+ln -s $PWD/build-xcode/Debug/externals $PWD/Jamoma/externals
+
+rm -rf $PWD/Jamoma/extensions
+mkdir $PWD/Jamoma/extensions
+cp -r $PWD/Jamoma/externals/j.loader.mxo $PWD/Jamoma/extensions/j.loader.mxo
+
+rm -rf $SUPPORT
+ln -s $PWD/build-xcode/Debug/support $PWD/Jamoma/support


### PR DESCRIPTION
…mber in the binary/install_name. Additionally, now copy the binaries for the core into a common location that can be easily copied/linked.  New "link.sh" script can be run to add sym links to this common location from the Jamoma Max package structure.